### PR TITLE
Fix broken build and warnings

### DIFF
--- a/client/Client/Quote.hs
+++ b/client/Client/Quote.hs
@@ -7,7 +7,7 @@ import Control.Monad.Trans.Resource
 import qualified Data.ByteString.Char8 as BS
 import Data.String
 import Data.Conduit.Binary hiding (mapM_)
-import Data.Conduit hiding (mapM_)
+import Data.Conduit
 
 import Finance.TradeKing
 

--- a/hstradeking.cabal
+++ b/hstradeking.cabal
@@ -1,5 +1,5 @@
 name: hstradeking
-version: 0.1.0
+version: 0.1.0.1
 cabal-version: >=1.8
 build-type: Simple
 license: BSD3
@@ -40,17 +40,18 @@ extra-source-files:
    client/Client/Quote.hs
 
 library
-    build-depends: base >= 3 && < 5, hoauth >=0.3.5, text >=0.11.3.1, bytestring >=0.9, containers,
-                   aeson >=0.6, old-locale, safe, conduit >=1.0.12, http-conduit >=2.0.0.0,
-                   resourcet >=0.4, RSA <=1.2.2.0, case-insensitive, lifted-base >=0.2,
-                   configurator >=0.2.0.2, vector, time, numbers
+    build-depends: base >= 4 && < 5, hoauth >=0.3.5, text >=1.2.2, bytestring >=0.10.6, containers >=0.4.2.1,
+                   aeson >=0.10, old-locale >=1.0.0.4, safe >=0.3.9, conduit >=1.2.6.1, http-conduit >=2.1.8,
+                   resourcet >=1.1.7, RSA <=1.2.2.0, case-insensitive >=1.2.0.5, lifted-base >=0.2.3.6,
+                   configurator >=0.3, vector >=0.11, time >=1.4, numbers >=3000.2.0.1
     exposed-modules: Finance.TradeKing Finance.TradeKing.Quotes Finance.TradeKing.Types
                      Finance.TradeKing.Service Finance.TradeKing.Config
     hs-source-dirs: src
 
 executable tradeking
-    build-depends: hstradeking ==0.1.0, base >= 3 && < 5, conduit >=1.0.12,
-                   bytestring >=0.9, resourcet >=0.4, transformers >=0.3
+    build-depends: hstradeking ==0.1.0.1, base >= 4 && < 5, conduit >=1.2.6.1,
+                   bytestring >=0.10.6, resourcet >=1.1.7, transformers >=0.4.3,
+                   conduit-extra >=1.1.9.2
     main-is: Client.hs
     hs-source-dirs: client
 

--- a/src/Finance/TradeKing/Quotes.hs
+++ b/src/Finance/TradeKing/Quotes.hs
@@ -8,6 +8,7 @@ import Finance.TradeKing.Service (invokeSimple, streamQuotes')
 import qualified Control.Exception.Lifted as E
 import Control.Applicative
 import Control.Monad
+import Control.Monad.Trans.Resource (ResourceT)
 
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import qualified Data.ByteString.Char8 as BS

--- a/src/Finance/TradeKing/Service.hs
+++ b/src/Finance/TradeKing/Service.hs
@@ -68,7 +68,8 @@ streamQuotes' tk stocks f = do
   oauthReq <- runOAuthM tok' $ signRq2 HMACSHA1 Nothing (fromJust . parseURL $ uri)
   let oauthReq' = unpackRq oauthReq
       req' = req { HttpC.requestHeaders = map (\(h,b) -> (CI.mk (fromString h), fromString b)) (Req.toList (reqHeaders oauthReq')) }
-  HttpC.withManager $ \manager -> do
-                           response <- HttpC.http req' manager
-                           let bsrc = HttpC.responseBody response
-                           f bsrc
+  manager <- HttpC.newManager HttpC.tlsManagerSettings
+  runResourceT $ do
+      response <- HttpC.http req' manager
+      let bsrc = HttpC.responseBody response
+      f bsrc


### PR DESCRIPTION
Had to make a couple changes to get `hstradeking` to build. Also, I've included a commit to remove the usage of `Network.HTTP.Client`'s depreciated `withManager` function.

For reference, my build was against the following package collection:

```
RSA 1.2.2.0
aeson 0.10.0.0
base 4.5.0.0
bytestring 0.10.6.0
case-insensitive 1.2.0.5
conduit 1.2.6.1
conduit-extra 1.1.9.2
configurator 0.3.0.0
containers 0.4.2.1
hoauth 0.3.5
hstradeking 0.1.0
http-conduit 2.1.8
lifted-base 0.2.3.6
numbers 3000.2.0.1
old-locale 1.0.0.4
resourcet 1.1.7
safe 0.3.9
text 1.2.2.0
time 1.4
transformers 0.4.3.0
vector 0.11.0.0
```
